### PR TITLE
Add task definitions and deterministic graders

### DIFF
--- a/nova_rl_env/graders.py
+++ b/nova_rl_env/graders.py
@@ -22,3 +22,81 @@
 # - No randomness in grading.
 # - No LLM calls in grading.
 # - Keep graders independent from deployment logic.
+
+from __future__ import annotations
+
+from typing import Any, Mapping, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .models import Action
+else:
+    Action = Any
+
+
+def _clamp_score(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _metric(state: Mapping[str, Any], name: str) -> float:
+    metrics = state.get("metrics", {})
+    if not isinstance(metrics, Mapping):
+        return 0.0
+    return _clamp_score(float(metrics.get(name, 0.0)))
+
+
+def _action_value(action: Action, name: str, default: Any) -> Any:
+    if isinstance(action, Mapping):
+        return action.get(name, default)
+    return getattr(action, name, default)
+
+
+def _latency_penalty(state: Mapping[str, Any]) -> float:
+    step_index = max(0, int(state.get("step_index", 0)))
+    batch = state.get("batch", {})
+    max_steps = 8
+    if isinstance(batch, Mapping):
+        max_steps = int(batch.get("max_steps", max_steps))
+    return _clamp_score(step_index / max_steps)
+
+
+def _quarantine_penalty(action: Action, quarantine_precision: float) -> float:
+    decision = _action_value(action, "decision", "")
+    threshold = float(_action_value(action, "threshold", 0.5))
+    if decision == "quarantine":
+        return _clamp_score((1.0 - quarantine_precision) * max(threshold, 0.0))
+    return _clamp_score(1.0 - quarantine_precision)
+
+
+def _grade_easy(state: Mapping[str, Any]) -> float:
+    return _metric(state, "promotion_precision")
+
+
+def _grade_medium(state: Mapping[str, Any], action: Action) -> float:
+    promotion_rate = _metric(state, "promotion_precision")
+    quarantine_precision = _metric(state, "quarantine_precision")
+    quarantine_penalty = _quarantine_penalty(action, quarantine_precision)
+    return _clamp_score(0.75 * promotion_rate - 0.25 * quarantine_penalty)
+
+
+def _grade_hard(state: Mapping[str, Any], action: Action) -> float:
+    promotion_rate = _metric(state, "promotion_precision")
+    quarantine_precision = _metric(state, "quarantine_precision")
+    quarantine_penalty = _quarantine_penalty(action, quarantine_precision)
+    latency_penalty = _latency_penalty(state)
+    return _clamp_score(
+        0.70 * promotion_rate
+        - 0.20 * quarantine_penalty
+        - 0.10 * latency_penalty
+    )
+
+
+def grade(task_id: str, state: dict, action: Action) -> float:
+    """Return a deterministic task score in the required 0.0 to 1.0 range."""
+
+    if task_id == "easy":
+        return _grade_easy(state)
+    if task_id == "medium":
+        return _grade_medium(state, action)
+    if task_id == "hard":
+        return _grade_hard(state, action)
+    raise ValueError(f"Unknown task_id: {task_id}")

--- a/nova_rl_env/tasks.py
+++ b/nova_rl_env/tasks.py
@@ -22,3 +22,83 @@
 # Constraints
 # - Keep the MVP compact.
 # - Do not add unnecessary task sprawl before the required three tasks are solid.
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+TASK_ORDER = ["easy", "medium", "hard"]
+
+TASKS: Dict[str, Dict[str, Any]] = {
+    "easy": {
+        "name": "Easy ETL Nulls and Duplicates",
+        "level": "easy",
+        "objective": "Fix null fields and obvious duplicate records before promotion.",
+        "batch_size": 100,
+        "anomaly_rate": 0.10,
+        "anomaly_types": ["null", "duplicate"],
+        "fault_complexity": "single-row obvious faults",
+        "schema_drift_prob": 0.0,
+        "max_steps": 8,
+        "scoring": {
+            "method": "promotion_rate",
+            "promotion_weight": 1.0,
+            "quarantine_penalty_weight": 0.0,
+            "latency_penalty_weight": 0.0,
+        },
+    },
+    "medium": {
+        "name": "Medium ETL Type and Date Repair",
+        "level": "medium",
+        "objective": "Fix type mismatches and malformed date values while avoiding over-quarantine.",
+        "batch_size": 100,
+        "anomaly_rate": 0.20,
+        "anomaly_types": [
+            "null",
+            "duplicate",
+            "type_mismatch",
+            "malformed_date",
+        ],
+        "fault_complexity": "mixed row-level data quality faults",
+        "schema_drift_prob": 0.0,
+        "max_steps": 8,
+        "scoring": {
+            "method": "weighted_promotion_with_quarantine_penalty",
+            "promotion_weight": 0.75,
+            "quarantine_penalty_weight": 0.25,
+            "latency_penalty_weight": 0.0,
+        },
+    },
+    "hard": {
+        "name": "Hard ETL Schema Drift and Correlated Faults",
+        "level": "hard",
+        "objective": "Handle schema drift and correlated multi-column faults without unsafe promotion.",
+        "batch_size": 100,
+        "anomaly_rate": 0.30,
+        "anomaly_types": [
+            "null",
+            "duplicate",
+            "type_mismatch",
+            "malformed_date",
+            "schema_drift",
+        ],
+        "fault_complexity": "schema drift plus correlated multi-column faults",
+        "schema_drift_prob": 0.10,
+        "max_steps": 8,
+        "scoring": {
+            "method": "full_r_system",
+            "alpha": 0.70,
+            "beta": 0.20,
+            "gamma": 0.10,
+        },
+    },
+}
+
+
+def get_task_config(task_id: str) -> Dict[str, Any]:
+    """Return a copy of the task configuration for the requested difficulty."""
+
+    if task_id not in TASKS:
+        raise ValueError(f"Unknown task_id: {task_id}")
+    return dict(TASKS[task_id])


### PR DESCRIPTION
Summary:
- Add easy, medium, and hard ETL task configs from the Nova RL roadmap.
- Add deterministic graders for promotion, quarantine penalty, and hard-mode latency penalty.
- Keep scores clamped to the required 0.0 to 1.0 range.

Tests:
- Syntax check for tasks.py, datagen.py, and graders.py.
- Integrated tasks -> datagen -> graders smoke test for all three task levels.
- Grader clamp/action compatibility checks.